### PR TITLE
Changed password escaping from double to single quotes

### DIFF
--- a/lib/list/cifs.js
+++ b/lib/list/cifs.js
@@ -154,8 +154,11 @@ function mount(options, log, callback) {
         if (!dir.startsWith('/')) {
             dir = '/' + dir;
         }
-        if (!options.pass.startsWith('"')) {
-            options.pass = '"' + options.pass + '"';
+        // use single quotes to ensure that characters like $ or \ will not be interpreted as variables or escaping sequences
+        // if-statment for compatiblity with "old" pre-escaped passwords
+        // https://stackoverflow.com/questions/6697753/difference-between-single-and-double-quotes-in-bash
+        if (!(options.pass.startsWith('"') || options.pass.startsWith("'"))) {
+            options.pass = "'" + options.pass + "'";
         }
         
         child_process.exec(`${rootMount} -t cifs -o ${options.user ? 'username=' + options.user + ',password=' + options.pass : ''},rw,file_mode=0777,dir_mode=0777,${options.smb} ${options.mount}${dir} ${backupDir}`, (error, stdout, stderr) => {

--- a/lib/scripts/01-mount.js
+++ b/lib/scripts/01-mount.js
@@ -35,8 +35,11 @@ function command(options, log, callback) {
     if (options.mountType === 'CIFS' && options.mount && !options.dir.startsWith('/') || options.mountType === 'NFS' && options.mount && !options.dir.startsWith('/')) {
         options.dir = '/' + options.dir;
     }
-    if (!options.pass.startsWith('"')) {
-        options.pass = '"' + options.pass + '"';
+    // use single quotes to ensure that characters like $ or \ will not be interpreted as variables or escaping sequences
+    // if-statment for compatiblity with "old" pre-escaped passwords
+    // https://stackoverflow.com/questions/6697753/difference-between-single-and-double-quotes-in-bash
+    if (!(options.pass.startsWith('"') || options.pass.startsWith("'"))) {
+        options.pass = "'" + options.pass + "'";
     }
 
     if (!options.mount) {


### PR DESCRIPTION
With double quotes it was not possible to use characters like \ or $. Single quotes should fix this problem.

Refers to: #184 

Further informations:
https://stackoverflow.com/questions/6697753/difference-between-single-and-double-quotes-in-bash