### PR TITLE
Update fixer command

### DIFF
--- a/docs/de/backitup.md
+++ b/docs/de/backitup.md
@@ -162,7 +162,7 @@ Hier eine Liste der bisher aufgetretenen Probleme und deren Lösungen sofern vor
     Führt bitte folgende Befehle auf eure Iobrokerumgebung in der Konsole aus:
 
     ```
-    curl -sL https://iobroker.net/fix.sh | bash -
+    curl -fsL https://iobroker.net/fix.sh | bash -
     sudo reboot
     ```
 8.  Solltet Ihr eine Fehlermeldung beim erstellen der Redis Datenbank bekommen, prüft bitte, ob euer User iobroker die Rechte hat und ob er in der User-Gruppe Redis vorhanden ist.

--- a/docs/en/backitup.md
+++ b/docs/en/backitup.md
@@ -161,7 +161,7 @@ Here is a list of problems encountered so far and their solutions, if any.
     In order to solve the problem with missing rights, there is now a fix for the installer script of iobroker.
     Please run the following commands on your Iobroker environment in the console:
     ```
-    curl -sL https://iobroker.net/fix.sh | bash -
+    curl -fsL https://iobroker.net/fix.sh | bash -
     sudo reboot
     ```
 7. If you get an error when creating the Redis database, please check if your user iobroker has the rights and if he exists in the user group Redis.


### PR DESCRIPTION
Since Github has outages today I've noticed that curl can output HTTP errors that bash doesn't understand. This changed command avoids cryptic errors in that case.