### PR TITLE
WebDav option to use self-signed certificates (and disable strict SSL checking).

### DIFF
--- a/lib/list/webdav.js
+++ b/lib/list/webdav.js
@@ -14,7 +14,7 @@ function list(restoreSource, options, types, log, callback) {
         if (wd_username && wd_pass && wd_url && (!restoreSource || restoreSource === 'webdav')) {
 
             const { createClient } = require("webdav");
-
+            var agent = require("https").Agent({rejectUnauthorized: false});
             let client;
             try {
                 client = createClient(
@@ -23,7 +23,8 @@ function list(restoreSource, options, types, log, callback) {
                         username: wd_username,
                         password: wd_pass,
                         maxBodyLength: Infinity,
-                        maxContentLength: Infinity
+                        maxContentLength: Infinity,
+                        httpsAgent: agent
                     }
                 );
             } catch (err) {
@@ -89,7 +90,7 @@ function getFile(options, fileName, toStoreName, log, callback) {
     if (wd_username && wd_pass && wd_url) {
 
         const { createClient } = require("webdav");
-
+        var agent = require("https").Agent({rejectUnauthorized: false});
         // copy file to backupDir
         let client;
         try {
@@ -99,7 +100,8 @@ function getFile(options, fileName, toStoreName, log, callback) {
                     username: wd_username,
                     password: wd_pass,
                     maxBodyLength: Infinity,
-                    maxContentLength: Infinity
+                    maxContentLength: Infinity,
+                    httpsAgent: agent
                 }
             );
         } catch (err) {

--- a/lib/scripts/65-webdav.js
+++ b/lib/scripts/65-webdav.js
@@ -110,7 +110,7 @@ async function command(options, log, callback) {
         }
 
         const { createClient } = require("webdav");
-
+        var agent = require("https").Agent({rejectUnauthorized: false});
         let client;
 
         try {
@@ -119,7 +119,8 @@ async function command(options, log, callback) {
                 {
                     username: options.username,
                     password: options.pass,
-                    maxBodyLength: Infinity
+                    maxBodyLength: Infinity,
+                    httpsAgent: agent
                 }
             );
         } catch (err) {

--- a/main.js
+++ b/main.js
@@ -205,13 +205,14 @@ function startAdapter(options) {
                 case 'testWebDAV':
                     if (obj.message) {
                         const { createClient } = require("webdav");
-
+                        var agent = require("https").Agent({rejectUnauthorized: false})
                         const client = createClient(
                             obj.message.config.host,
                             {
                                 username: obj.message.config.username,
                                 password: obj.message.config.password,
-                                maxBodyLength: Infinity
+                                maxBodyLength: Infinity,
+                                httpsAgent: agent
                             });
 
                         client


### PR DESCRIPTION
With this additional option it will be possible to use self signed certificates in webdav. Sure it should be handled as _option_ for those who know what they do;)

Damit wäre auch der Zusatz in Readme überflüssig: "Um eine Verbindung aufbauen zu können, muss der Hostname der Cloud alle Sicherheitszertifikate erfüllen. Eine Verbindung mit lokaler IP-Adresse ist nicht möglich, da diese keine Lets Encrypt Zertifikate enthält."

Änderung muss noch an 3 Stellen vorgenommen werden (ich hab's bei mir quick&dirty gemacht):
/opt/iobroker/node_modules/iobroker.backitup/lib/list
22:webdav.js
103:webdav.js
/opt/iobroker/node_modules/iobroker.backitup/lib/scripts
120:65-webdav.js

Habe bei mir aus github installiert, läuft)