### PR TITLE
Resolving the Unreadable error message in telegram

### DIFF
--- a/lib/scripts/90-telegram.js
+++ b/lib/scripts/90-telegram.js
@@ -63,7 +63,7 @@ function command(options, log, callback) {
                     errorMessage += '\nmount: ' + options.context.errors.mount;
                     try {
                         const formatPass = options.cifs.pass.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-                        errorMessage = (options.cifs ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
+                        errorMessage = (options.cifs && formatPass ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
                     } catch (e) {
                         // ignore
                     }
@@ -84,7 +84,7 @@ function command(options, log, callback) {
                     errorMessage += '\nmysql: ' + options.context.errors.mysql;
                     try {
                         const formatPass = options.mysql.pass.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-                        errorMessage = (options.mysql ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
+                        errorMessage = (options.mysql && formatPass ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
                     } catch (e) {
                         // ignore
                     }
@@ -93,10 +93,10 @@ function command(options, log, callback) {
                     errorMessage += '\ngrafana: ' + options.context.errors.grafana;
                     try {
                         const formatPass = options.grafana.pass.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-                        errorMessage = (options.grafana ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
+                        errorMessage = (options.grafana && formatPass ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
 
                         const formatApiKey = options.grafana.apiKey.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-                        errorMessage = (options.grafana ? errorMessage.replace(new RegExp(formatApiKey, 'g'), "****") : errorMessage);
+                        errorMessage = (options.grafana && formatApiKey ? errorMessage.replace(new RegExp(formatApiKey, 'g'), "****") : errorMessage);
                     } catch (e) {
                         // ignore
                     }
@@ -111,7 +111,7 @@ function command(options, log, callback) {
                     errorMessage += '\nwebdav: ' + options.context.errors.webdav;
                     try {
                         const formatPass = options.webdav.pass.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-                        errorMessage = (options.webdav ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
+                        errorMessage = (options.webdav && formatPass ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
                     } catch (e) {
                         // ignore
                     }
@@ -120,7 +120,7 @@ function command(options, log, callback) {
                     errorMessage += '\npgsql: ' + options.context.errors.pgsql;
                     try {
                         const formatPass = options.pgsql.pass.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-                        errorMessage = (options.pgsql ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
+                        errorMessage = (options.pgsql && formatPass ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
                     } catch (e) {
                         // ignore
                     }
@@ -129,7 +129,7 @@ function command(options, log, callback) {
                     errorMessage += '\nccu: ' + options.context.errors.ccu;
                     try {
                         const formatPass = options.ccu.pass.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-                        errorMessage = (options.ccu ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
+                        errorMessage = (options.ccu && formatPass ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
                     } catch (e) {
                         // ignore
                     }
@@ -138,7 +138,7 @@ function command(options, log, callback) {
                     errorMessage += '\nftp: ' + options.context.errors.ftp;
                     try {
                         const formatPass = options.ftp.pass.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-                        errorMessage = (options.ftp ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
+                        errorMessage = (options.ftp && formatPass ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
                     } catch (e) {
                         // ignore
                     }
@@ -147,7 +147,7 @@ function command(options, log, callback) {
                     errorMessage += '\ndropbox: ' + options.context.errors.dropbox;
                     try {
                         const formatPass = options.dropbox.accessToken.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-                        errorMessage = (options.dropbox ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
+                        errorMessage = (options.dropbox && formatPass ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
                     } catch (e) {
                         // ignore
                     }
@@ -156,7 +156,7 @@ function command(options, log, callback) {
                     errorMessage += '\ngoogledrive: ' + options.context.errors.googledrive;
                     try {
                         const formatPass = options.googledrive.accessJson.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-                        errorMessage = (options.googledrive ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
+                        errorMessage = (options.googledrive && formatPass ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
                     } catch (e) {
                         // ignore
                     }
@@ -166,7 +166,7 @@ function command(options, log, callback) {
                     errorMessage += '\ncifs: ' + options.context.errors.cifs;
                     try {
                         const formatPass = options.cifs.pass.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-                        errorMessage = (options.cifs ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
+                        errorMessage = (options.cifs && formatPass ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
                     } catch (e) {
                         // ignore
                     }
@@ -178,7 +178,7 @@ function command(options, log, callback) {
                     errorMessage += '\numount: ' + options.context.errors.umount;
                     try {
                         const formatPass = options.cifs.pass.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-                        errorMessage = (options.cifs ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
+                        errorMessage = (options.cifs && formatPass ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
                     } catch (e) {
                         // ignore
                     }


### PR DESCRIPTION
The [issue]( https://github.com/simatec/ioBroker.backitup/issues/652) is described.
It's rare issue, in specific circumstances, but ...
In case of the pass for any option is empty, code
```
                        const formatPass = options.cifs.pass.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
                        errorMessage = (options.cifs ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
```
will add near any symbol in error message the four *. 
That's why I propose to check if the formatPass string is not empty too.
I.e.
```
                        const formatPass = options.cifs.pass.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
                        errorMessage = (options.cifs && formatPass ? errorMessage.replace(new RegExp(formatPass, 'g'), "****") : errorMessage);
```
Possible the similar fix required for any other report target ...