### PR TITLE
introduce secure FTP connections using explicit TLS

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -1015,6 +1015,10 @@
                 </div>
                 <div class="row ftp">
                     <div class="input-field col s12">
+                        <input class="value" id="ftpSecure" type="checkbox"/>
+                        <label for="ftpSecure" class="translate">Secure FTP connection (explicit TLS)</label>
+                    </div>
+                    <div class="input-field col s12">
                         <input class="value" id="ftpDeleteOldBackup" type="checkbox"/>
                         <label for="ftpDeleteOldBackup" class="translate">Delete old FTP-Backups</label>
                     </div>

--- a/io-package.json
+++ b/io-package.json
@@ -342,6 +342,7 @@
     "ftpEnabled": false,
     "ftpHost": "",
     "ftpPort": 21,
+    "ftpSecure": false,
     "ftpDir": "/backupDir",
     "ftpUser": "",
     "ftpPassword": "",

--- a/lib/list/ftp.js
+++ b/lib/list/ftp.js
@@ -7,6 +7,7 @@ function list(restoreSource, options, types, log, callback) {
     const ftp_user = options.user !== undefined ? options.user : options.ftp && options.ftp.user !== undefined ? options.ftp.user : '';
     const ftp_pass = options.pass !== undefined ? options.pass : options.ftp && options.ftp.pass !== undefined ? options.ftp.pass : '';
     const ftp_port = options.port !== undefined ? options.port : options.ftp && options.ftp.port !== undefined ? options.ftp.port : 21;
+    const ftp_secure = options.secure !== undefined ? options.secure : options.ftp && options.ftp.secure !== undefined ? options.ftp.secure : false;
     const ftp_dir = options.dir !== undefined ? options.dir : options.ftp && options.ftp.dir !== undefined ? options.ftp.dir : '/';
     const ftp_ownDir = options.ownDir !== undefined ? options.ownDir : options.ftp && options.ftp.ownDir !== undefined ? options.ftp.ownDir : false;
     const ftp_dirMinimal = options.dirMinimal !== undefined ? options.dirMinimal : options.ftp && options.ftp.dirMinimal !== undefined ? options.ftp.dirMinimal : '/';
@@ -68,6 +69,7 @@ function list(restoreSource, options, types, log, callback) {
         const srcFTP = {
             host: ftp_host,
             port: ftp_port || 21,
+            secure: ftp_secure || false,
             user: ftp_user,
             password: ftp_pass
         };
@@ -84,6 +86,7 @@ function getFile(options, fileName, toStoreName, log, callback) {
     const ftp_user = options.user !== undefined ? options.user : options.ftp && options.ftp.user !== undefined ? options.ftp.user : '';
     const ftp_pass = options.pass !== undefined ? options.pass : options.ftp && options.ftp.pass !== undefined ? options.ftp.pass : '';
     const ftp_port = options.port !== undefined ? options.port : options.ftp && options.ftp.port !== undefined ? options.ftp.port : 21;
+    const ftp_secure = options.secure !== undefined ? options.secure : options.ftp && options.ftp.secure !== undefined ? options.ftp.secure : false;
     const ftp_dir = options.dir !== undefined ? options.dir : options.ftp && options.ftp.dir !== undefined ? options.ftp.dir : '/';
     const ftp_ownDir = options.ownDir !== undefined ? options.ownDir : options.ftp && options.ftp.ownDir !== undefined ? options.ftp.ownDir : false;
     const ftp_dirMinimal = options.dirMinimal !== undefined ? options.dirMinimal : options.ftp && options.ftp.dirMinimal !== undefined ? options.ftp.dirMinimal : '/';
@@ -158,6 +161,7 @@ function getFile(options, fileName, toStoreName, log, callback) {
         const srcFTP = {
             host: ftp_host,
             port: ftp_port || 21,
+            secure: ftp_secure || false,
             user: ftp_user,
             password: ftp_pass
         };

--- a/lib/scripts/50-ftp.js
+++ b/lib/scripts/50-ftp.js
@@ -141,6 +141,7 @@ function command(options, log, callback) {
         const srcFTP = {
             host: options.host,
             port: options.port || 21,
+            secure: options.secure || false,
             user: options.user,
             password: options.pass
         };

--- a/main.js
+++ b/main.js
@@ -629,6 +629,7 @@ function initConfig(secret) {
         user: adapter.config.ftpUser,                       // username for FTP Server
         pass: adapter.config.ftpPassword ? decrypt(secret, adapter.config.ftpPassword) : '',  // password for FTP Server
         port: adapter.config.ftpPort || 21,                  // FTP port
+        secure: adapter.config.ftpSecure || false,  // secure FTP connection
         ignoreErrors: adapter.config.ignoreErrors
     };
 


### PR DESCRIPTION
Add a new checkbox to the FTP settings and pass the "secure" option to the FTP client to enable TLS for both control and data connection.

From the docs of the FTP module (https://www.npmjs.com/package/ftp):
> **connect**(< object >config) - (void) - Connects to an FTP server. Valid config properties:
> * [...]
> * secure - _mixed_ - Set to true for both control and data connection encryption, 'control' for control connection encryption only, or 'implicit' for implicitly encrypted control connection (this mode is deprecated in modern times, but usually uses port 990) **Default:** false

We could make the settings a select box to allow (explicit, implicit, unencrypted), but implicit is not widely used anymore, so imho the explicit true/false checkbox should be sufficient here.

~I've added German translation, as I am a native speaker.~