### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "iobroker.backitup",
   "version": "2.8.1",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "description": "ioBroker.backitup enables the cyclic creation of backups of an IoBroker / Homematic installation",
   "author": {


### PR DESCRIPTION
Adapter-core 3.x.x is known to fail when installed at node 14 due to npm7 not installing peer dependencies. So this adapter requires node 16