### PR TITLE
Update package.json - require node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "iobroker.backitup",
   "version": "2.11.0",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "description": "ioBroker.backitup allows you to backup and restore your ioBroker installation and other systems, such as databases, Zigbee, scripts and many more.",
   "author": {


### PR DESCRIPTION
As this adapter is no longer tested with node 16 and node 16 is EOL since some time too this adapter should require node 18 minimum now.