### PR TITLE
36-grafana.js: Using api key also for getting datasources

### DIFF
--- a/lib/scripts/36-grafana.js
+++ b/lib/scripts/36-grafana.js
@@ -42,10 +42,7 @@ async function getData(options, log, dashboardDir, folderDir, datasourceDir, das
                 const dataSourcesRequest = await axios({
                     method: 'get',
                     url: `${options.protocol}://${options.host}:${options.port}/api/datasources`,
-                    auth: {
-                        username: options.username,
-                        password: options.pass,
-                    },
+                    headers: { 'Authorization': `Bearer ${options.apiKey}` },
                     responseType: 'json',
                     httpsAgent: new https.Agent({
                         rejectUnauthorized: options.signedCertificates,


### PR DESCRIPTION
All other grafana requests already use api key.
Only for getting data sources still username and password were used that won't work in some installations.