### PR TITLE
Add dependency for adapter tests in CI workflow

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -36,6 +36,8 @@ jobs:
 
   # Runs adapter tests on all supported node versions and OSes
   adapter-tests:
+    needs: [check-and-lint]
+    
     if: contains(github.event.head_commit.message, '[skip ci]') == false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Startin adapter testa only after check-and-lint has completed successfully reduced the overall system load andsaves some resources. The delay is not noticeable as check-and-lint is really fast.

solves S3014